### PR TITLE
feat: add rutorrent service to bob

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1689447223,
+        "narHash": "sha256-A5vQBtWYamvGf3c2IEhAmwIkXBzuzrkpnMYbLvc+lEY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "f5b03feb33629cb2b6dd513935637e8cc718a5ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1689373857,
+        "narHash": "sha256-mtBksyvhhT98Zsm9tYHuMKuLwUKDwv+BGTl6K5nOGhY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dfdbcc428f365071f0ca3888f6ec8c25c3792885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_rutorrent": {
+      "locked": {
+        "lastModified": 1677206201,
+        "narHash": "sha256-Z8AueWtVf2Lg3CiEEdTmGqtbvVklOqab/X1Eit/bv0U=",
+        "owner": "bolives-hax",
+        "repo": "nixpkgs",
+        "rev": "3431fb040d59db639c083f49bf972a678704f18b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bolives-hax",
+        "ref": "add-rutorrent-service",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs_rutorrent": "nixpkgs_rutorrent"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     nixpkgs_rutorrent.url = "github:bolives-hax/nixpkgs/add-rutorrent-service";
   };
 
-  outputs = { nixpkgs, home-manager, ... }:
+  outputs = { nixpkgs, home-manager, nixpkgs_rutorrent, ... }:
     let
       system = "x86_64-linux";
 
@@ -26,7 +26,12 @@
 
           modules = [
             ./system/bob/configuration.nix
+            ./system/bob/rutorrent.nix
           ];
+
+	  specialArgs = {
+		inherit nixpkgs_rutorrent;
+	  };
         };
 
         deepthought = nixpkgs.lib.nixosSystem {

--- a/system/bob/rutorrent.nix
+++ b/system/bob/rutorrent.nix
@@ -1,0 +1,25 @@
+# Edit this configuration file to define what should be installed on
+# your system.  Help is available in the configuration.nix(5) man page
+# and in the NixOS manual (accessible by running `nixos-help`).
+
+{ config, system, pkgs, nixpkgs_rutorrent, ... }:
+
+{
+  # make rutorrent package available to the system
+  nixpkgs.overlays = [
+    (final: prev: {
+      rutorrent = nixpkgs_rutorrent.legacyPackages.${pkgs.system}.rutorrent;
+    })
+  ];
+
+  imports =
+    [
+      "${nixpkgs_rutorrent}/nixos/modules/services/web-apps/rutorrent.nix" # pull in this service from the fork
+      "${nixpkgs_rutorrent}/nixos/modules/services/torrent/rtorrent.nix" # use the fork's instead of upstream's
+    ];
+
+  services.rutorrent.enable = true;
+  users.users.rtorrent.isNormalUser = true; # needs to be enabled lest something else be enabled (some mutual exclusion config option)
+  disabledModules = [ "services/torrent/rtorrent.nix" ]; # avoid conflict with upstream nixpkgs rtorrent service
+}
+


### PR DESCRIPTION
# Description
This PR uses `github:bolives-hax/nixpkgs/add-rutorrent-service` to add `rutorrent` as a service to `bob`'s system derivation.